### PR TITLE
About page background fix

### DIFF
--- a/css/about.css
+++ b/css/about.css
@@ -10,7 +10,6 @@
 }
 
 #content {
-    padding: 50px 0 0 0;
     display: -webkit-flex;
     display: -ms-flexbox;
     display: flex;
@@ -20,7 +19,7 @@
 }
 
 #slogan {
-    padding: 0.5em 0 1em 2em;
+    padding: 3em 1em 1em 2em;
     display: inline-block;
     text-align:center;
 }


### PR DESCRIPTION
Brought the About page background up to the top while preserving the vertical space balance around the slogan